### PR TITLE
change advance_select max_items attr to type :any to allow passing in…

### DIFF
--- a/lib/components/advance_select.ex
+++ b/lib/components/advance_select.ex
@@ -11,7 +11,7 @@ defmodule Paleta.Components.AdvanceSelect do
   attr(:value, :string, default: nil)
   attr(:field, Phoenix.HTML.FormField, default: nil)
   attr(:options, :list, default: [])
-  attr(:max_items, :integer, default: 1)
+  attr(:max_items, :any, default: 1)
   attr(:required, :boolean, default: false)
   attr(:label, :string, default: nil)
   attr(:rest, :global)


### PR DESCRIPTION
… nil

To allow an unlimited number of `max_items`, you have to set the value to `nil` -- but since `max_items` is declared as an `integer`, using `nil` causes compiler warnings everywhere that it's used, like:

```
warning: attribute "max_items" in component Paleta.Components.AdvanceSelect.advance_select/1 must be an :integer, got: nil
    │
 21 │         <.advance_select field={@form[:thing_to_select]} options={@options} label="Select some options" max_items={nil} />
    │         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/some_component.ex:21: (file)
```

Previously `max_items` didn't have a default, so it wasn't necessary to set it to `nil` to allow "unlimited" selection, but a commit a little while back changed the default to 1.

Addresses #22 